### PR TITLE
[Temporary] Use mavlink with indigo version 

### DIFF
--- a/aerial_robot.rosinstall
+++ b/aerial_robot.rosinstall
@@ -15,3 +15,15 @@
     local-name: sensor_interface
     uri: https://github.com/tongtybj/sensor_interface.git
     version: master
+
+# mavlink
+# This should be temporary link, since this is fixed to be indigo version
+- git:
+    local-name: mavlink
+    uri: https://github.com/mavlink/mavlink-gbp-release.git
+    version: release/indigo/mavlink/2016.5.20-0
+
+- git:
+    local-name: mavros
+    uri: https://github.com/mavlink/mavros.git
+    version: 0.17.5


### PR DESCRIPTION
Since there is big change between indigo version and kinetic version about mavlink, and the aerial_robot_comm is based on the indigo version. We add the repository about mavlink in .rosinstall since we have to use indigo version for aeiral_robot_comm